### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM alpine:3.14@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a as fetcher
+FROM --platform=$BUILDPLATFORM alpine:3.14@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a as fetcher
 
 RUN apk add -U wget ca-certificates
 
 # renovate: datasource=github-releases depName=miguelmota/ipdr
-ARG IPDR_VERSION=0.1.6
-ARG OS=linux
-ARG ARCH=amd64
+ARG IPDR_VERSION=v0.1.6
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 
-RUN wget https://github.com/miguelmota/ipdr/releases/download/v${IPDR_VERSION}/ipdr_${IPDR_VERSION}_${OS}_${ARCH}.tar.gz
-RUN tar zxvf ipdr_${IPDR_VERSION}_${OS}_${ARCH}.tar.gz
+RUN wget https://github.com/miguelmota/ipdr/releases/download/${IPDR_VERSION}/ipdr_${IPDR_VERSION#v}_${TARGETOS}_${TARGETARCH}.tar.gz
+RUN tar zxvf ipdr_${IPDR_VERSION#v}_${TARGETOS}_${TARGETARCH}.tar.gz
 RUN mv ipdr /ipdr
 
-FROM alpine:3.14@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:
 COPY --from=fetcher /ipdr /usr/bin/ipdr
 ENTRYPOINT ["ipdr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN wget https://github.com/miguelmota/ipdr/releases/download/${IPDR_VERSION}/ip
 RUN tar zxvf ipdr_${IPDR_VERSION#v}_${TARGETOS}_${TARGETARCH}.tar.gz
 RUN mv ipdr /ipdr
 
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static
 COPY --from=fetcher /ipdr /usr/bin/ipdr
 ENTRYPOINT ["ipdr"]


### PR DESCRIPTION
- Switch VERSION to tag (ie: include leading `v`)
- Use distroless for final image
- Use buildx --platform args to download using build platform