### PR TITLE
Avoid generating target names that end with `-`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,19 +5,19 @@ RUN apk add -U wget ca-certificates
 # renovate: datasource=github-releases depName=miguelmota/ipdr
 ENV IPDR_VERSION=v0.1.7
 
-FROM --platform=$BUILDPLATFORM fetcher-base AS fetcher-linux-arm-v6
+FROM --platform=$BUILDPLATFORM fetcher-base AS fetcher-linux-arm-v6-x
 ENV SUFFIX=linux_armv6
 
-FROM --platform=$BUILDPLATFORM fetcher-base AS fetcher-linux-arm64-
+FROM --platform=$BUILDPLATFORM fetcher-base AS fetcher-linux-arm64--x
 ENV SUFFIX=linux_arm64
 
-FROM --platform=$BUILDPLATFORM fetcher-base AS fetcher-linux-amd64-
+FROM --platform=$BUILDPLATFORM fetcher-base AS fetcher-linux-amd64--x
 ENV SUFFIX=linux_amd64
 
-FROM --platform=$BUILDPLATFORM fetcher-base AS fetcher-linux-386-
+FROM --platform=$BUILDPLATFORM fetcher-base AS fetcher-linux-386--x
 ENV SUFFIX=linux_386
 
-FROM --platform=$BUILDPLATFORM fetcher-$TARGETOS-$TARGETARCH-$TARGETVARIANT AS fetcher
+FROM --platform=$BUILDPLATFORM fetcher-$TARGETOS-$TARGETARCH-$TARGETVARIANT-x AS fetcher
 
 RUN wget https://github.com/miguelmota/ipdr/releases/download/${IPDR_VERSION}/ipdr_${IPDR_VERSION#v}_${SUFFIX}.tar.gz
 RUN tar zxvf ipdr_${IPDR_VERSION#v}_${SUFFIX}.tar.gz


### PR DESCRIPTION
Recent buildx actions fail with:
```
error: failed to solve: invalid context name fetcher-linux-arm64-: invalid reference format
Error: buildx failed with: error: failed to solve: invalid context name fetcher-linux-arm64-: invalid reference format
```

Add a trailing 'safe' character to all targets